### PR TITLE
ci: add incremental-mutants job to execute cargo mutants against PR diff

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,1 @@
+profile = "mutants"

--- a/.github/workflows/mutations.yml
+++ b/.github/workflows/mutations.yml
@@ -1,0 +1,42 @@
+name: Test mutants
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  incremental-mutants:
+    name: Incremental mutants test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Relative diff
+        run: |
+          git branch -av
+          git diff origin/${{ github.base_ref }}.. | tee git.diff
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install Rust toolchain
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Mutants
+        run: |
+          cargo mutants --no-shuffle -vV --exclude "example-crates/**" --in-diff git.diff -- --all-targets
+      - name: Archive mutants.out
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutants-incremental.out
+          path: mutants.out

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 
 # Ignore media (should go into media branch)
 *.gif
+
+# Ignore cargo-mutants generated output
+/mutants.out*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ print_stderr = "deny"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+
+[profile.mutants]
+inherits = "test"
+debug = "none"
+opt-level = 3


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Mutation is a way to assess the quality of the test. By changing the code under test, it allows to identify conditions that cannot be detected by the actual tests, and improve them to catch them properly.

Fixes #6 

### Notes to the reviewers

Mutation may be very slow in some scenarios, to allow a fast feedback loop without consuming too much execution time, the mutations are going to be performed on the diff between the code in the PR and the code in the `master` branch.

Also, a cargo profile `mutants` was added to remove debugging symbols from compilation and optimize the code.

### Checklists

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing
