### PR TITLE
test: add unit test for get smallest outpoint

### DIFF
--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -104,3 +104,159 @@ pub fn compute_shared_secret(sk: &SecretKey, pk: &PublicKey) -> PublicKey {
 
     PublicKey::from_slice(&ss_bytes).expect("computationally unreachable: can only fail if public key is invalid in the first place or sk is")
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use bitcoin::OutPoint;
+    use bitcoin::Txid;
+
+    #[test]
+    fn test_get_smallest_outpoint_different_txids_and_vouts() {
+        let outpoints = vec![
+            OutPoint {
+                txid: Txid::from_slice(&[3u8; 32]).unwrap(),
+                vout: 2,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[2u8; 32]).unwrap(),
+                vout: 1,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[5u8; 32]).unwrap(),
+                vout: 3,
+            },
+        ];
+
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [2u8; 36];
+        expected_bytes[32..36].copy_from_slice(&1u32.to_le_bytes());
+
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot create silent payment script pubkey without outpoints")]
+    fn test_get_smallest_outpoint_empty() {
+        let outpoints: Vec<OutPoint> = vec![];
+        get_smallest_lexicographic_outpoint(&outpoints);
+    }
+
+    // Additional test: same txid, different vouts
+    #[test]
+    fn test_get_smallest_outpoint_identical_txid_different_vouts() {
+        let txid = Txid::from_slice(&[0u8; 32]).unwrap();
+        let outpoints = vec![
+            OutPoint { txid, vout: 10 },
+            OutPoint { txid, vout: 2 },
+            OutPoint { txid, vout: 5 },
+        ];
+
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [0u8; 36];
+        expected_bytes[32..36].copy_from_slice(&2u32.to_le_bytes());
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    fn test_get_smallest_outpoint_same_vout_different_txid() {
+        let outpoints = vec![
+            OutPoint {
+                txid: Txid::from_slice(&[2u8; 32]).unwrap(),
+                vout: 7,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[1u8; 32]).unwrap(),
+                vout: 7,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[3u8; 32]).unwrap(),
+                vout: 7,
+            },
+        ];
+
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [1u8; 36];
+        expected_bytes[32..36].copy_from_slice(&7u32.to_le_bytes());
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    fn test_get_smallest_outpoint_edge_case_max_vout() {
+        let outpoints = vec![
+            OutPoint {
+                txid: Txid::from_slice(&[1u8; 32]).unwrap(),
+                vout: u32::MAX,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[1u8; 32]).unwrap(),
+                vout: u32::MIN,
+            },
+        ];
+
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [1u8; 36];
+        expected_bytes[..32].copy_from_slice(&[1u8; 32]);
+        expected_bytes[32..36].copy_from_slice(&0u32.to_le_bytes());
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    fn test_get_smallest_outpoint_txid_takes_precedence() {
+        let outpoints = vec![
+            OutPoint {
+                txid: Txid::from_slice(&[8u8; 32]).unwrap(),
+                vout: 0,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&[5u8; 32]).unwrap(),
+                vout: 100,
+            },
+        ];
+
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [5u8; 36];
+        expected_bytes[32..36].copy_from_slice(&100u32.to_le_bytes());
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    fn test_get_smallest_outpoint_txid_endianness_matters() {
+        // big endian: 0x[00][00][00][01]
+        // big endian: 0x[a1][b1][c1][d1]
+        let mut txid_bytes_be = [0u8; 32];
+        txid_bytes_be[0] = 1;
+
+        // little endian: 0x[01][00][00][00]
+        // little endian: 0x[a2][b2][c2][d2]
+        let mut txid_bytes_le = [0u8; 32];
+        txid_bytes_le[31] = 1;
+
+        let outpoints = vec![
+            OutPoint {
+                txid: Txid::from_slice(&txid_bytes_be).unwrap(),
+                vout: 1,
+            },
+            OutPoint {
+                txid: Txid::from_slice(&txid_bytes_le).unwrap(),
+                vout: 1,
+            },
+        ];
+
+        // if Txid is big endian then: [a1] < [a2] => expected_bytes = txid_bytes_be
+        // if Txid is little endian then: [d2] < [d1] => expected_bytes = txid_bytes_le
+        let result = get_smallest_lexicographic_outpoint(&outpoints);
+
+        let mut expected_bytes = [0u8; 36];
+        expected_bytes[31] = 1;
+        expected_bytes[32..36].copy_from_slice(&1u32.to_le_bytes());
+
+        assert_eq!(result, expected_bytes);
+    }
+}


### PR DESCRIPTION
### Description

Add unit test for function `bdk_sp::silentpayments::get_smallest_lexicographic_outpoint`.

Fixes #11 

### Checklists

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing