### PR TITLE
Replace `get_smallest_lexicographic_outpoint` by `LexMin`

### DIFF
--- a/silentpayments/src/receive/error.rs
+++ b/silentpayments/src/receive/error.rs
@@ -6,6 +6,14 @@ pub enum SpReceiveError {
     Secp256k1Error(bitcoin::secp256k1::Error),
     /// Secp256k1 error
     SliceError(bitcoin::key::FromSliceError),
+    /// Cannot derive silent payment output without input prevout outpoints
+    NoOutpoints(crate::LexMinError),
+}
+
+impl From<crate::LexMinError> for SpReceiveError {
+    fn from(e: crate::LexMinError) -> Self {
+        Self::NoOutpoints(e)
+    }
 }
 
 impl From<bitcoin::secp256k1::Error> for SpReceiveError {
@@ -32,6 +40,7 @@ impl std::fmt::Display for SpReceiveError {
             }
             SpReceiveError::Secp256k1Error(e) => write!(f, "Silent payment receive error: {e}"),
             SpReceiveError::SliceError(e) => write!(f, "Silent payment receive error: {e}"),
+            Self::NoOutpoints(e) => write!(f, "Silent payment sending error: {e}"),
         }
     }
 }

--- a/silentpayments/src/send/error.rs
+++ b/silentpayments/src/send/error.rs
@@ -4,6 +4,8 @@ pub enum SpSendError {
     Secp256k1Error(bitcoin::secp256k1::Error),
     /// BIP 32 error
     Bip32Error(bitcoin::bip32::Error),
+    /// Cannot derive silent payment output without input prevout outpoints
+    NoOutpoints(crate::LexMinError),
     /// No available inputs for shared secret derivation
     MissingInputsForSharedSecretDerivation,
     /// PSBT missing witness
@@ -14,6 +16,12 @@ pub enum SpSendError {
     IndexError(bitcoin::blockdata::transaction::OutputsIndexError),
     /// PSBT missing silent payment placeholder script
     MissingPlaceholderScript,
+}
+
+impl From<crate::LexMinError> for SpSendError {
+    fn from(e: crate::LexMinError) -> Self {
+        Self::NoOutpoints(e)
+    }
 }
 
 impl From<bitcoin::secp256k1::Error> for SpSendError {
@@ -40,6 +48,7 @@ impl std::fmt::Display for SpSendError {
             Self::Bip32Error(e) => write!(f, "Silent payment sending error: {e}"),
             Self::Secp256k1Error(e) => write!(f, "Silent payment sending error: {e}"),
             Self::IndexError(e) => write!(f, "From PSBT: {e}"),
+            Self::NoOutpoints(e) => write!(f,  "Silent payment sending error: {e}"),
             Self::MissingInputsForSharedSecretDerivation => write!(f, "No available inputs for shared secret derivation"),
             Self::MissingWitness => write!(
                 f,


### PR DESCRIPTION
### Description

The new LexMin is a zero allocation cost struct that allows computing the minimal lexicographic outpoint in the same loop where other logic is contained, avoiding the intermediate step of extracting all the outpoints from their TxIn into a separated collection to sort them.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing
