### PR TITLE
Use bdk-tx dependency from bitcoindevkit/bdk-tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bdk_tx"
 version = "0.1.0"
-source = "git+https://github.com/nymius/bdk-tx?branch=feat/add-ChangeDescriptor-enum#bcb018f61ff2f38e0b48aa1e19810b47831130a1"
+source = "git+https://github.com/bitcoindevkit/bdk-tx?branch=master#ac547ce3c40919f1dcd4de7e966c3d8f20dd497c"
 dependencies = [
  "bdk_coin_select",
  "miniscript",

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 
 [dependencies]
 bdk_sp = { version = "0.1.0", path = "../silentpayments" }
-bdk_tx = { version = "0.1.0", git = "https://github.com/nymius/bdk-tx", branch = "feat/add-ChangeDescriptor-enum" }
+bdk_tx = { version = "0.1.0", git = "https://github.com/bitcoindevkit/bdk-tx", branch = "master" }
 indexer = { version = "0.1.0", path = "../indexer" , features = ["serde"]}
 serde = { version = "1.0.219", optional = true }
 


### PR DESCRIPTION
### Description

Now that the bitcoindevkit/bdk-tx#18 has been merged, we can start tracking changes in the main repository’s master branch again.