### PR TITLE
Update bdk-tx outputHash in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
               cargoLock = {
                 lockFile = ./Cargo.lock;
                 outputHashes = {
-                  "bdk_tx-0.1.0" = "sha256-kND3yQ80ld8bQskf1Y+aDgJnZegTEviVV9d2zc7wwuQ=";
+                  "bdk_tx-0.1.0" = "sha256-29weg2aCn+4MHC9DJLSBd09RS7igbTqF/fKRd5u5ef4=";
                 };
               };
 


### PR DESCRIPTION
### Description

After pinning `bdk-tx` in `Cargo.toml`, the `outputHash` of the crate changed, so `flake.nix` needs an update to build the flake properly. 