### PR TITLE
Use `just cli` on `_init_regtest_sp` `doc/tabconf7/justfile` recipe

### DIFF
--- a/doc/tabconf7/justfile
+++ b/doc/tabconf7/justfile
@@ -483,7 +483,7 @@ _init_regtest_sp:
   #!/usr/bin/env bash
   if [ ! -f ".regtest_tr_xprv" ]; then
     rm -rf ".sp_cli2_regtest.db"
-    BLOCKCHAININFO=$(bitcoin-cli --datadir=$BITCOIN_DATA_DIR --chain=regtest getblockchaininfo)
+    BLOCKCHAININFO=$(just cli getblockchaininfo)
     HEIGHT=$(echo $BLOCKCHAININFO | jq -r '.blocks')
     HASH=$(echo $BLOCKCHAININFO | jq -r '.bestblockhash')
     DB_PATH=".sp_cli2_regtest.db" sp-cli2 create --network regtest --birthday-height $HEIGHT --birthday-hash $HASH | jq -r '.tr_xprv' > ".regtest_tr_xprv"


### PR DESCRIPTION
**Description**

The changes 098edf74fffcc7ff79b72a8e5589a59f0d01800b introduced a bug and uncovered the real issue behind the `_init_regtest_sp` command.

Up to that commit the initialization was using the output from the signet chain set up inside the nix environment. As the environment was built ensuring signet was running, the issue was not evident, until someone tried using it outside of the nix environment.

The 098edf74fffcc7ff79b72a8e5589a59f0d01800b changes assumed the command was just referring to the wrong blockchain, and applied a fix along these lines. This change later uncovered other issues.

The simplest fix is to use the agnostic `just cli` recipe, that only knows about the regtest ports and uses the credentials set up during initialization.