### PR TITLE
Update develop environment to work with bdk-cli v3.0.0

### DIFF
--- a/doc/tabconf7/flake.lock
+++ b/doc/tabconf7/flake.lock
@@ -7,11 +7,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756673831,
-        "narHash": "sha256-Hg4CjE67rT7Twd5nC3Al9e9Cg2oZHuSvvx//Zc6ZnUA=",
+        "lastModified": 1776085626,
+        "narHash": "sha256-1bsi6TCrc30h4X71t9pClZf+8Q98xfGxysxhRhEmfwE=",
         "owner": "nymius",
         "repo": "bdk-cli",
-        "rev": "ccde9f0c12ef3d0cce169f3895b5466c742e7aea",
+        "rev": "c53890d16e129ab89d03f627f816f9209126105a",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1760284886,
-        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -109,16 +109,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1760524057,
-        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760754684,
-        "narHash": "sha256-B4+gmoRuvjZGKvDQtMjYkqyA89gZLjrXObZrXFrcKOk=",
+        "lastModified": 1758767687,
+        "narHash": "sha256-znUulOqcL/Kkdr7CkyIi8Z1pTGXpi54Xg2FmlyJmv4A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "16c233757f1b200936f1b39961c901733936c616",
+        "rev": "b8bcc09d4f627f4e325408f6e7a85c3ac31f0eeb",
         "type": "github"
       },
       "original": {

--- a/doc/tabconf7/flake.nix
+++ b/doc/tabconf7/flake.nix
@@ -59,6 +59,7 @@
           paths = with pkgs;
             [
               jq
+              dasel
               podman
               qrencode
               xclip
@@ -95,8 +96,6 @@
               export RPC_PASS=$(cat $BITCOIN_DATA_DIR/signet/.cookie | cut -d ':' -f2)
               export RPC_URL="http://127.0.0.1:38332/"
               export TR_XPRV=$(cat ".tr_xprv")
-              export EXT_DESCRIPTOR=$(cat "$BDK_DATA_DIR/.external_descriptor")
-              export INT_DESCRIPTOR=$(cat "$BDK_DATA_DIR/.internal_descriptor")
               export EXTRA_PEER=$(bitcoin-cli --datadir=$BITCOIN_DATA_DIR --chain=signet getpeerinfo | jq -r 'map(select(.servicesnames[] | contains ("COMPACT"))) | .[0].addr' | cut -sd ":" -f1)
             '';
           };
@@ -125,7 +124,7 @@
 
                           cat > "$EXTRA_SCRIPTS/signet-bdk" <<'EOF'
               #!/usr/bin/env bash
-              bdk-cli --datadir "$BDK_DATA_DIR" --network signet wallet -w signet -e "$EXT_DESCRIPTOR" -i "$INT_DESCRIPTOR" -c rpc -u http://localhost:38332/ "$BITCOIN_DATA_DIR/signet/.cookie" -d sqlite "$@"
+              bdk-cli --datadir "$BDK_DATA_DIR" wallet -w signet "$@"
               EOF
 
                           chmod +x "$EXTRA_SCRIPTS/signet-bdk"
@@ -164,12 +163,16 @@
                           export RPC_PASS=$(cat $BITCOIN_DATA_DIR/signet/.cookie | cut -d ':' -f2)
                           export RPC_URL="http://127.0.0.1:38332/"
 
-                          if [ ! -f "$BDK_DATA_DIR/.external_descriptor" ] || [ ! -f "$BDK_DATA_DIR/.internal_descriptor" ]; then
+                          IS_SIGNET_WALLET_AVAILABLE=$(bdk-cli --datadir "$BDK_DATA_DIR" wallets | jq -r 'any(.wallets[].name; . == "signet")')
+                          if [ $IS_SIGNET_WALLET_AVAILABLE == "true" ]; then
+                            dasel -i toml --root 'wallets.signet.rpc_user = $RPC_USER' < .bdk/config.toml > .bdk/config.toml.tmp && mv .bdk/config.toml.tmp .bdk/config.toml
+                            dasel -i toml --root 'wallets.signet.rpc_password = $RPC_PASS' < .bdk/config.toml > .bdk/config.toml.tmp && mv .bdk/config.toml.tmp .bdk/config.toml
+                          else
                             rm -rf $BDK_DATA_DIR/signet
-                            rm -rf $BDK_DATA_DIR/regtest
                             XPRV=$(bdk-cli --datadir $BDK_DATA_DIR --network signet key generate | jq -r '.xprv')
-                            echo "tr($XPRV/86h/1h/0h/0/*)" > "$BDK_DATA_DIR/.external_descriptor"
-                            echo "tr($XPRV/86h/1h/0h/1/*)" > "$BDK_DATA_DIR/.internal_descriptor"
+                            EXT_DESCRIPTOR=$(echo "tr($XPRV/86h/1h/0h/0/*)")
+                            INT_DESCRIPTOR=$(echo "tr($XPRV/86h/1h/0h/1/*)")
+                            bdk-cli --datadir "$BDK_DATA_DIR" --network signet wallet -w signet config -e "$EXT_DESCRIPTOR" -i "$INT_DESCRIPTOR" -c rpc -u $RPC_URL $BITCOIN_DATA_DIR/signet/.cookie -d sqlite
                           fi
 
                           if [ ! -f ".tr_xprv" ]; then
@@ -183,8 +186,7 @@
                           just init
 
                           export TR_XPRV=$(cat ".tr_xprv")
-                          export EXT_DESCRIPTOR=$(cat "$BDK_DATA_DIR/.external_descriptor")
-                          export INT_DESCRIPTOR=$(cat "$BDK_DATA_DIR/.internal_descriptor")
+
                           export EXTRA_PEER=$(bitcoin-cli --datadir=$BITCOIN_DATA_DIR --chain=signet getpeerinfo | jq -r 'map(select(.servicesnames[] | contains ("COMPACT"))) | .[0].addr' | cut -sd ":" -f1)
 
                           trap "bitcoin-cli --datadir=$BITCOIN_DATA_DIR --chain=signet stop && just stop" EXIT

--- a/doc/tabconf7/justfile
+++ b/doc/tabconf7/justfile
@@ -28,9 +28,7 @@ regtest-sp COMMAND *ARGS:
 [doc("Send a command to bdk-cli on regtest")]
 regtest-bdk COMMAND *ARGS:
   #!/usr/bin/env bash
-  export EXT_DESCRIPTOR=$(cat "{{bdk_data_dir}}/.external_descriptor")
-  export INT_DESCRIPTOR=$(cat "{{bdk_data_dir}}/.internal_descriptor")
-  bdk-cli --datadir "{{bdk_data_dir}}" --network regtest wallet -w regtest -e "$EXT_DESCRIPTOR" -i "$INT_DESCRIPTOR" -c rpc -u http://localhost:18443/ $(just local_cookie_path) -d sqlite {{COMMAND}} {{ARGS}}
+  bdk-cli --datadir "{{bdk_data_dir}}" --network regtest wallet -w regtest {{COMMAND}} {{ARGS}}
 
 [group("Podman")]
 [doc("Set up VM to run containers")]
@@ -229,7 +227,8 @@ startcontainer: (create "false" "1.0.0")
   podman --connection sptabconf7 start RegtestBitcoinEnv
 
 _clean_regtest_bdk:
-  rm -rf {{bdk_data_dir}}/regtest
+  rm -rf "{{bdk_data_dir}}/regtest"
+  dasel -i toml --root "wallets.regtest = null" < .bdk/config.toml > .bdk/config.toml.tmp && mv .bdk/config.toml.tmp .bdk/config.toml
 
 _clean_regtest_sp:
   #!/usr/bin/env bash
@@ -356,13 +355,6 @@ cookie:
   just podcmd "cat $(just envpath)/regtest/.cookie | cut -d ':' -f2"
 
 [group("Bitcoin Core")]
-[doc("Write the current session cookie to file and return path")]
-local_cookie_path:
-  #!/usr/bin/env bash
-  just podcmd "cat $(just envpath)/regtest/.cookie" > .regtest_cookie
-  echo ".regtest_cookie"
-
-[group("Bitcoin Core")]
 [doc("Mine a block, or mine <BLOCKS> number of blocks")]
 mine BLOCKS="1" ADDRESS="bcrt1q6gau5mg4ceupfhtyywyaj5ge45vgptvawgg3aq":
   just cli generatetoaddress {{BLOCKS}} {{ADDRESS}}
@@ -470,13 +462,15 @@ sendto ADDRESS:
 
 _init_regtest_bdk:
   #!/usr/bin/env bash
-  mkdir -p {{bdk_data_dir}}
-  if [ ! -f "{{bdk_data_dir}}/.external_descriptor" ] || [ ! -f "{{bdk_data_dir}}/.internal_descriptor" ]; then
-    rm -rf {{bdk_data_dir}}/signet
-    rm -rf {{bdk_data_dir}}/regtest
-    XPRV=$(bdk-cli --datadir {{bdk_data_dir}} --network signet key generate | jq -r '.xprv')
-    echo "tr($XPRV/86h/1h/0h/0/*)" > "{{bdk_data_dir}}/.external_descriptor"
-    echo "tr($XPRV/86h/1h/0h/1/*)" > "{{bdk_data_dir}}/.internal_descriptor"
+  regtest_wallet_created=$(bdk-cli --datadir "{{bdk_data_dir}}" wallets | jq -r 'any(.wallets[].name; . == "regtest")')
+  if [ $regtest_wallet_created == "false" ]; then
+    mkdir -p "{{bdk_data_dir}}"
+    rm -rf "{{bdk_data_dir}}/regtest"
+    COOKIE=$(just podcmd "cat $(just envpath)/regtest/.cookie")
+    XPRV=$(bdk-cli --datadir "{{bdk_data_dir}}" --network regtest key generate | jq -r '.xprv')
+    EXT_DESCRIPTOR=$(echo "tr($XPRV/86h/1h/0h/0/*)")
+    INT_DESCRIPTOR=$(echo "tr($XPRV/86h/1h/0h/1/*)")
+    bdk-cli --datadir "{{bdk_data_dir}}" --network regtest wallet -w regtest config -e "$EXT_DESCRIPTOR" -i "$INT_DESCRIPTOR" -c rpc -u http://localhost:18443/ -a "$COOKIE" -d sqlite
   fi
 
 _init_regtest_sp:


### PR DESCRIPTION
bdk-cli new release added a configuration file to set wallet parameters and removed the flags from cli.

This change broke some of the wrapper commands designed for use inside the development environment, forcing the current update.

As the new configuration format is a toml file, this change adds the `dasel` tool to the nix environment to be able to rewrite auth keys on the bdk file on each environment restart.
