### PR TITLE
Scanning fails when birthday block does not exist

### DIFF
--- a/cli/v2/src/main.rs
+++ b/cli/v2/src/main.rs
@@ -335,13 +335,7 @@ async fn main() -> anyhow::Result<()> {
                 let hash = wallet.chain().tip().hash();
                 HeaderCheckpoint::new(height, hash)
             } else {
-                let checkpoint = wallet
-                    .chain()
-                    .get(wallet.birthday.height)
-                    .expect("should be something");
-                let height = checkpoint.height();
-                let hash = checkpoint.hash();
-                HeaderCheckpoint::new(height, hash)
+                HeaderCheckpoint::new(wallet.birthday.height, wallet.birthday.hash)
             };
 
             tracing::info!(


### PR DESCRIPTION
When the wallet is just created, there is no blocks on the `LocalChain`, making the request of the birthday checkpoint impossible to serve.

This change avoids the issue by directly using the height and hash set on the wallet.birthday field.