### PR TITLE
fix: scan-rpc ignores wallet birthday

### DIFF
--- a/cli/v2/src/main.rs
+++ b/cli/v2/src/main.rs
@@ -484,6 +484,9 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 wallet.birthday.height
             };
+
+            tracing::info!("Synchronizing from block height {}", start_height);
+
             let mut emitter = Emitter::new(
                 &rpc_client,
                 wallet.chain().tip(),

--- a/cli/v2/src/main.rs
+++ b/cli/v2/src/main.rs
@@ -479,10 +479,15 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::ScanRpc { rpc_args } => {
             let rpc_client = rpc_args.new_client()?;
+            let start_height = if wallet.birthday.height <= wallet.chain().tip().height() {
+                wallet.chain().tip().height()
+            } else {
+                wallet.birthday.height
+            };
             let mut emitter = Emitter::new(
                 &rpc_client,
                 wallet.chain().tip(),
-                0,
+                start_height,
                 NO_EXPECTED_MEMPOOL_TXIDS,
             );
 


### PR DESCRIPTION
### Description

Closes #59.

`scan-rpc` was constructing the `bdk_bitcoind_rpc::Emitter` with `start_height = 0`, so every invocation began emitting blocks from genesis and crawled the entire chain history regardless of the wallet's `birthday`.

This change mirrors the logic that `scan-cbf` already implements.

### Notes to the reviewers

No tests were added: there are no existing tests under `cli/v2/` and `just check` / `just test` are both configured to exclude `bdk_sp_cli_v2`.

### Execution trace

Demo setup on signet:

| | |
|--|--|
| chain tip height | `304930` |
| wallet birthday height | `299930` (= tip − 5000) |
| wallet birthday hash | `00000012361b7baaa62a7b357c4127d463a4ed7cdfc5a243bbdaca90dad2ce9b` |

For each run a fresh DB was used (`sp-cli2 create --network signet --birthday-height 299930 --birthday-hash <hash>`), then `sp-cli2 scan-rpc` against a fully-synced local bitcoind. The CLI's existing periodic print reports `synced to <hash> @ <height>` — the `<height>` column is what tells us where the emitter is actually iterating.

#### Before (`master`, `start_height = 0`)

```
[  6.000065s] synced to 00000038493ebf22ee17073e9a9ce55c5f11808f4272e5d3b8b9c674a039e0a0 @ 11227 | total: 0 BTC
[ 12.000166s] synced to 000000a33061ffb8531c5d5bb40ebb48c8286f282309572d95971b9f11d6aa43 @ 23166 | total: 0 BTC
[ 18.000744s] synced to 0000011818c862dae0a387d7901b574a742827c1687ff908060ecf819fb93ddc @ 31798 | total: 0 BTC
[ 24.016146s] synced to 0000001597db5fda531b2734041c4fa52d16b986185041936b7f690348da32e8 @ 32513 | total: 0 BTC
[ 30.038584s] synced to 00000116bda6d95f3c50839ac523bdcf76298fef95d06c1aad83247cdfb45034 @ 33290 | total: 0 BTC
[ 36.060852s] synced to 00000110129983cc5b5bfc7a8c4fe81f61c4c92f36dc29c878cc341ad1cee261 @ 33589 | total: 0 BTC
[ 42.121567s] synced to 000000eb259b8c138c2f81e0be0947c205aa3d04e458381927692e69a4dd79f3 @ 34365 | total: 0 BTC
[ 48.126183s] synced to 000000241a2a3f5d966ccd8103de67fccc4fa55de814584d032ec4f3811311a1 @ 34796 | total: 0 BTC
[  54.13878s] synced to 0000015f7653cf609b55921b215818089b608a6648fa09a06518dbf938193ffb @ 35596 | total: 0 BTC
[  60.20082s] committed to db (took 0.13710761s)
[ 60.200836s] synced to 00000140a2e599e2833ac4e0caecf6f4b1c02dbae75d3d9cb3e6efb75f08c33e @ 35921 | total: 0 BTC
[  66.24587s] synced to 0000013d1082bfac244cc410a3f28972732a50fbca3abcab98346685852edd23 @ 36584 | total: 0 BTC
[ 72.252594s] synced to 0000002eea671447d457699003f4a19f90624a04525fcd88b420597fce7b5f3b @ 36972 | total: 0 BTC
[  78.25634s] synced to 00000130258222ac881ba99c78cd997c28a38f62df9ad1863ed3bfc6d42c42c4 @ 37653 | total: 0 BTC
[  84.49703s] synced to 0000011e8ac4dacb5260f621537fd65458b194a33c37bf61e900ae19cd48252a @ 38163 | total: 0 BTC
```

After 90 s the scanner is still around height `~38000`.

#### After (`fix/scan-rpc-birthday`)

```
[ 6.1241345s] synced to 0000000648b6526f6b6e407701601ddb9a1bf153f52591f3b93f970b89ce0175 @ 299977 | total: 0 BTC
[ 12.788164s] synced to 00000012c784191d95451f8d8da76b8bf9f5d94ea4443ac4f376b4c508d2dd53 @ 300003 | total: 0 BTC
[ 19.336086s] synced to 000000114aca31ddc01e5670d6bfa98f70fe3af25614148900c79ef43d3a10e9 @ 300012 | total: 0 BTC
[ 26.982027s] synced to 00000012a6d5d2b0617cb030fa384456838958311e45cb413bfdc3b12e06aa90 @ 300023 | total: 0 BTC
[  33.76034s] synced to 00000007e4639d14f618e9ba93cca174d2b7480f30e37e8a26cc9c313bcda52e @ 300029 | total: 0 BTC
[ 44.722466s] synced to 00000010d02533683a65f4c7673d68db60070da1eed98757c07054e1df136181 @ 300037 | total: 0 BTC
[  51.04577s] synced to 00000005a334703667ad6e88ad352fc14b66156d330a8fe58c0e9c08ed3851df @ 300042 | total: 0 BTC
[ 57.384346s] synced to 000000004b485832d218e61410d9cb852d9c47a4666125507f677db274bff336 @ 300050 | total: 0 BTC
[ 64.078415s] committed to db (took 0.00096677s)
[ 64.078445s] synced to 00000001d4cc7dfc79462e814a2957510e2a1eaaba3469ea52aefaabaa9f1a53 @ 300056 | total: 0 BTC
```

The first 6 s print already shows the emitter at height `299977` — only 47 blocks past the wallet birthday — and the scanner iterates forward from there toward the tip.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing


