### PR TITLE
fix(send): reject eligible inputs without private keys

### DIFF
--- a/silentpayments/src/send/error.rs
+++ b/silentpayments/src/send/error.rs
@@ -16,7 +16,7 @@ pub enum SpSendError {
     IndexError(bitcoin::blockdata::transaction::OutputsIndexError),
     /// PSBT missing silent payment placeholder script
     MissingPlaceholderScript,
-    /// Error while requesting keys
+    /// A required private key is unavailable or does not match the input
     KeyError,
     /// There are not enough silent payment derivations for all targeted outputs
     MissingDerivations,
@@ -55,7 +55,7 @@ impl std::fmt::Display for SpSendError {
             Self::Secp256k1Error(e) => write!(f, "Silent payment sending error: {e}"),
             Self::IndexError(e) => write!(f, "From PSBT: {e}"),
             Self::NoOutpoints(e) => write!(f,  "Silent payment sending error: {e}"),
-            Self::KeyError => write!(f, "Silent payment sending error: error while requesting private keys from key provider"),
+            Self::KeyError => write!(f, "Silent payment sending error: required private key is unavailable or does not match the input"),
             Self::MissingInputsForSharedSecretDerivation => write!(f, "No available inputs for shared secret derivation"),
             Self::MissingWitness => write!(
                 f,

--- a/silentpayments/src/send/psbt/mod.rs
+++ b/silentpayments/src/send/psbt/mod.rs
@@ -208,7 +208,7 @@ where
 
 /// Collects input data required for silent payment derivation from a [`Psbt`].
 ///
-/// This function iterates through all [`Psbt`] inputs, request private keys where available,
+/// This function iterates through all [`Psbt`] inputs, requests keys for every eligible input,
 /// and determines the lexicographically smallest outpoint for the silent payment protocol.
 ///
 /// # Arguments
@@ -253,12 +253,12 @@ where
                                     Err(SpSendError::KeyError)
                                 }
                             }
-                            Ok(None) => Ok(None),
-                            Err(_) => Err(SpSendError::KeyError),
+                            Ok(None) | Err(..) => Err(SpSendError::KeyError),
                         }
                     }
                     _ => get_non_taproot_secret(psbt_input, k, secp)
-                        .map_err(|_| SpSendError::KeyError),
+                        .map_err(|_| SpSendError::KeyError)
+                        .and_then(|secret| secret.map(Some).ok_or(SpSendError::KeyError)),
                 })
                 .transpose()?
                 .flatten()

--- a/silentpayments/src/send/psbt/tests.rs
+++ b/silentpayments/src/send/psbt/tests.rs
@@ -649,10 +649,50 @@ mod collect_input_data {
 
         let result = collect_input_data(&psbt, &key_provider, &secp);
 
-        assert!(matches!(
-            result.unwrap_err(),
-            SpSendError::MissingInputsForSharedSecretDerivation
-        ));
+        assert!(matches!(result.unwrap_err(), SpSendError::KeyError));
+    }
+
+    #[test]
+    fn missing_p2wpkh_key_for_one_of_multiple_eligible_inputs() {
+        let sp_codes = setup_sp_codes();
+        let sp_code = &sp_codes[0];
+        let outputs = vec![get_placeholder_txout(1000, sp_code)];
+        let mut psbt = create_test_psbt(outputs);
+        let (priv_key, xonly_pk, script_pubkey, witness) = create_p2tr_input_data();
+        let key_source = create_key_source();
+        psbt.inputs[0]
+            .tap_key_origins
+            .insert(xonly_pk, (vec![], key_source.clone()));
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(10000),
+            script_pubkey,
+        });
+        psbt.inputs[0].final_script_witness = Some(witness);
+
+        let (_, missing_pubkey, missing_script_pubkey, missing_witness) =
+            create_non_p2tr_input_data();
+        let mut missing_txin = psbt.unsigned_tx.input[0].clone();
+        missing_txin.previous_output.vout = 1;
+        psbt.unsigned_tx.input.push(missing_txin);
+
+        let mut missing_psbt_input = psbt.inputs[0].clone();
+        missing_psbt_input.tap_key_origins.clear();
+        missing_psbt_input
+            .bip32_derivation
+            .insert(missing_pubkey, key_source);
+        missing_psbt_input.witness_utxo = Some(TxOut {
+            value: Amount::from_sat(10000),
+            script_pubkey: missing_script_pubkey,
+        });
+        missing_psbt_input.final_script_witness = Some(missing_witness);
+        psbt.inputs.push(missing_psbt_input);
+
+        let key_provider = MockKeyProvider::default().with_xonly_key(xonly_pk, priv_key);
+        let secp = Secp256k1::new();
+
+        let result = collect_input_data(&psbt, &key_provider, &secp);
+
+        assert!(matches!(result.unwrap_err(), SpSendError::KeyError));
     }
 
     #[test]

--- a/silentpayments/src/send/psbt/tests.rs
+++ b/silentpayments/src/send/psbt/tests.rs
@@ -696,6 +696,45 @@ mod collect_input_data {
     }
 
     #[test]
+    fn ineligible_input_without_key_is_skipped() {
+        let sp_codes = setup_sp_codes();
+        let sp_code = &sp_codes[0];
+        let outputs = vec![get_placeholder_txout(1000, sp_code)];
+        let mut psbt = create_test_psbt(outputs);
+        let (priv_key, xonly_pk, script_pubkey, witness) = create_p2tr_input_data();
+        let key_source = create_key_source();
+        psbt.inputs[0]
+            .tap_key_origins
+            .insert(xonly_pk, (vec![], key_source));
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(10000),
+            script_pubkey,
+        });
+        psbt.inputs[0].final_script_witness = Some(witness);
+
+        let mut ineligible_txin = psbt.unsigned_tx.input[0].clone();
+        ineligible_txin.previous_output.vout = 1;
+        psbt.unsigned_tx.input.push(ineligible_txin);
+
+        let mut ineligible_psbt_input = psbt.inputs[0].clone();
+        ineligible_psbt_input.tap_key_origins.clear();
+        ineligible_psbt_input.witness_utxo = Some(TxOut {
+            value: Amount::from_sat(10000),
+            script_pubkey: ScriptBuf::new(),
+        });
+        ineligible_psbt_input.final_script_witness = Some(Witness::new());
+        psbt.inputs.push(ineligible_psbt_input);
+
+        let key_provider = MockKeyProvider::default().with_xonly_key(xonly_pk, priv_key);
+        let secp = Secp256k1::new();
+
+        let result = collect_input_data(&psbt, &key_provider, &secp);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().scripts_with_secrets.len(), 1);
+    }
+
+    #[test]
     fn get_prevout_error() {
         let sp_codes = setup_sp_codes();
         let sp_code = &sp_codes[0];


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Looking through `derive_sp` I noticed it can continue when the private key for an eligible input is missing as long as it finds a key for another input. That gives the sender an incomplete input key sum which won’t match what the receiver calculates, so this PR returns `KeyError` instead. (Inputs that aren’t eligible for silent payments are still skipped)

### Notes to the reviewers

Added coverage for a missing key among multiple eligible inputs and for skipping an ineligible input.

### Changelog notice

Return an error when an eligible silent payment input key is missing.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
