### PR TITLE
Release `bdk_sp@0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "bdk_sp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bdk_testenv",

--- a/cli/v1/Cargo.toml
+++ b/cli/v1/Cargo.toml
@@ -8,7 +8,7 @@ name = "sp-cli1"
 path = "src/main.rs"
 
 [dependencies]
-bdk_sp = { version = "0.1.0", path = "../../silentpayments/", features = ["serde"]}
+bdk_sp = { version = "0.2.0", path = "../../silentpayments/", features = ["serde"]}
 bdk_file_store = "0.21.0"
 bdk_chain = { version = "0.23.0", features = ["serde", "miniscript"]}
 bdk_bitcoind_rpc = { version = "0.20.0" }

--- a/cli/v2/Cargo.toml
+++ b/cli/v2/Cargo.toml
@@ -8,7 +8,7 @@ name = "sp-cli2"
 path = "src/main.rs"
 
 [dependencies]
-bdk_sp = { version = "0.1.0", path = "../../silentpayments/", features = ["serde", "psbt_sp_spend"]}
+bdk_sp = { version = "0.2.0", path = "../../silentpayments/", features = ["serde", "psbt_sp_spend"]}
 bdk_file_store = "0.21.0"
 bdk_bitcoind_rpc = { version = "0.20.0" }
 bdk_coin_select = { version = "0.4.0" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ libfuzzer_fuzz = ["libfuzzer-sys"]
 stdin_fuzz = []
 
 [dependencies]
-bdk_sp = { version = "0.1.0", path = "../silentpayments" }
+bdk_sp = { version = "0.2.0", path = "../silentpayments" }
 afl = { version = "0.12", optional = true }
 honggfuzz = { version = "0.5", optional = true, default-features = false }
 libfuzzer-sys = { version = "0.4", optional = true }

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 [dependencies]
 bdk_bitcoind_rpc = "0.18.0"
 bdk_chain = { version = "0.23.0", features = ["serde"] }
-bdk_sp = { version = "0.1.0", path = "../silentpayments", features = ["serde"] }
+bdk_sp = { version = "0.2.0", path = "../silentpayments", features = ["serde"] }
 bitcoin = "0.32.6"
 serde = { version = "1.0.219", optional = true }
 

--- a/silentpayments/CHANGELOG.md
+++ b/silentpayments/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0
+
+- Fix bug that allows the creation of silent payment outputs without collecting
+  all the eligible input private keys. #63
+
 # 0.1.0
 
 - Functions for encoding and decoding Silent Payment Codes (BIP352).

--- a/silentpayments/Cargo.toml
+++ b/silentpayments/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_sp"
 description = "Experimental BIP 352 library"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors.workspace = true
 
 [dependencies]
-bdk_sp = { version = "0.1.0", path = "../silentpayments" }
+bdk_sp = { version = "0.2.0", path = "../silentpayments" }
 bdk_tx = { version = "0.1.0", git = "https://github.com/bitcoindevkit/bdk-tx", rev = "8d201770ffc81f89d4d3ae92c362f9f936ad5958" }
 indexer = { version = "0.1.0", path = "../indexer" , features = ["serde"]}
 serde = { version = "1.0.219", optional = true }


### PR DESCRIPTION
This release includes a bug fix that allowed the creation of silent payment outputs without collecting all the eligible input private keys.