### PR TITLE
fix: return an error for empty silent payment payloads

### DIFF
--- a/silentpayments/src/encoding/mod.rs
+++ b/silentpayments/src/encoding/mod.rs
@@ -380,7 +380,10 @@ impl TryFrom<&str> for SilentPaymentCode {
         let hrp = checked_hrpstring.hrp();
         let mut payload = checked_hrpstring.fe32_iter::<&mut dyn Iterator<Item = u8>>();
 
-        let version = payload.nth(0).into_iter().collect::<Vec<_>>()[0].to_u8();
+        let version = payload
+            .next()
+            .ok_or(VersionError::WrongPayloadLength)?
+            .to_u8();
         let data = payload.fes_to_bytes().collect::<Vec<u8>>();
         let keys = match version {
             0 => {
@@ -658,6 +661,15 @@ mod test {
         #[test]
         fn vector_10_fail_to_parse_mainnet_code_with_invalid_checksum() {
             assert_encoding(10);
+        }
+
+        #[test]
+        fn fail_to_parse_code_with_empty_payload() {
+            let error = SilentPaymentCode::try_from("sp10ajr90").unwrap_err();
+            assert_eq!(
+                "payload length does not match version spec",
+                error.to_string()
+            );
         }
 
         #[test]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Generic Bech32m permits an empty payload, but `SilentPaymentCode::try_from` assumes the decoded payload contains a version and panics when it does not. This returns `WrongPayloadLength` instead and adds regression coverage.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

Return an error instead of panicking when parsing a silent payment code with an empty payload.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
