### PR TITLE
ci(mutants): build the baseline with --all-features

### DIFF
--- a/.github/workflows/mutations.yml
+++ b/.github/workflows/mutations.yml
@@ -33,7 +33,7 @@ jobs:
           tool: cargo-mutants
       - name: Mutants
         run: |
-          cargo mutants --no-shuffle -vV --exclude "cli/**" --in-diff git.diff -- --all-targets --all-features
+          cargo mutants --no-shuffle -vV --exclude "cli/**" --in-diff git.diff --cargo-arg=--all-features -- --all-targets
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
The `Incremental mutants test` lane is currently dead: it fails at the unmutated baseline on every PR, so no mutants are ever tested. The last run on master, 783c63c9, is red for the same reason.

Args after `--` are handed to the test phase only, so the baseline build runs with default features. `bdk_sp` gates `serde` behind an optional feature while its test scaffolding derives `Deserialize`, so the test targets do not compile without it and the build fails before mutation starts. Reproduces on a clean master worktree with `cargo check -p bdk_sp --tests`.

Passing the feature through `--cargo-arg` fixes it, since that applies to every cargo invocation including the build. It also has to come out of the trailing args: `--cargo-arg` already adds it to the test command, and cargo rejects `--all-features` twice.

Verified locally against the diff from #70, which previously died at the baseline:

```
7 mutants tested in 83s: 6 caught, 1 unviable
```

Unrelated, noted while here and left alone: this workflow has `on: push: branches: [main]` while the default branch is `master`, so that trigger never fires. The job is gated on `github.event_name == 'pull_request' anyway, so it changes nothing today.