### PR TITLE
refactore(test): ignore slow tests locally during pre-push, still run them in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
             toolchain: ${{ matrix.rust.version }}
       - name: Test
         run: cargo test --no-fail-fast --all-features
+      - name: Slow Test
+        run: "cargo test --no-fail-fast --all-features -- --ignored slow::"
 
   fmt-clippy:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@ alias c := check
 alias f := fmt
 alias t := test
 alias p := pre-push
+alias ts := test-slow
+alias ta := test-all
 
 [doc("List all available commands.")]
 default:
@@ -25,9 +27,16 @@ check:
 fmt:
   cargo +nightly fmt
 
-[doc("Run all tests on the workspace with all features")]
+[doc("Run fast tests  on the workspace with all features (skips tests annotated with #[ignore])")]
 test:
   cargo test --workspace --exclude sp_fuzz --exclude bdk_sp_cli_v1 --exclude bdk_sp_cli_v2 --all-features
 
 [doc("Run pre-push suite: format, check, and test")]
 pre-push: fmt check test
+
+[doc("Run the slow tests that `test`/`pre-push` skip")]
+test-slow:
+  cargo test --workspace --exclude sp_fuzz --exclude bdk_sp_cli_v1 --exclude bdk_sp_cli_v2 --all-features -- --ignored slow::
+
+[doc("Run all tests including slow/ignored tests on the workspace with all features")]
+test-all: pre-push test-slow

--- a/silentpayments/tests/functional_tests/bip352_vectors/receive.rs
+++ b/silentpayments/tests/functional_tests/bip352_vectors/receive.rs
@@ -273,7 +273,12 @@ fn input_keys_intermediate_sum_is_zero_but_final_sum_is_non_zero() {
     check_cases(26);
 }
 
-#[test]
-fn maximum_per_group_recipient_limit_k_max_is_exceeded() {
-    check_cases(27);
+mod slow {
+    use super::*;
+
+    #[test]
+    #[ignore = "slow test"]
+    fn maximum_per_group_recipient_limit_k_max_is_exceeded() {
+        check_cases(27);
+    }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This is a follow up #75 

### Notes to the reviewers

I group slow but correct/implemented tests under a nested mod slow { .. } block and add #[ignore]. This excludes them from local cargo test runs (just test/pre-push), but CI targets them all using a single filter: cargo test -- --ignored slow::. slow tests should now be added in mod slow{..} block in any file or crate. Also added `just test-slow` (alias just ts) and `just test-all` (alias just ta) since slow tests are still real tests someone may want to run before trusting a change.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `just p` (fmt, clippy and test) before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
